### PR TITLE
micro-optimizaciones 

### DIFF
--- a/app/src/main/java/com/grupo3/vinilos/album/service/AlbumRepository.kt
+++ b/app/src/main/java/com/grupo3/vinilos/album/service/AlbumRepository.kt
@@ -19,14 +19,14 @@ class AlbumRepository {
 
     suspend fun getSongs(albumId: Int): List<SongDto> {
         val potentialSongs = CacheManager.getInstance().getSongs(albumId)
-        return if(potentialSongs.isEmpty()){
-            Log.d("Cache decision", "get from network")
+        return if(!potentialSongs.first){
+            Log.d("Cache decision", "albumId: ${albumId} - getting songs from network")
             val songs = albumsService.getSongs(albumId)
             CacheManager.getInstance().addSongs(albumId, songs)
             songs
         } else{
-            Log.d("Cache decision", "return ${potentialSongs.size} elements from cache")
-            potentialSongs
+            Log.d("Cache decision", "albumId: ${albumId} - return ${potentialSongs.second.size} elements from cache")
+            potentialSongs.second
         }
     }
 }

--- a/app/src/main/java/com/grupo3/vinilos/network/CacheManager.kt
+++ b/app/src/main/java/com/grupo3/vinilos/network/CacheManager.kt
@@ -5,7 +5,7 @@ import com.grupo3.vinilos.album.dto.SongDto
 object CacheManager {
 
     private var instance: CacheManager? = null
-    private var songs: HashMap<Int, List<SongDto>> = hashMapOf()
+    private val songsCache = mutableMapOf<Int, Pair<Boolean, List<SongDto>>>()
 
     @Synchronized
     fun getInstance(): CacheManager {
@@ -14,13 +14,13 @@ object CacheManager {
         }
     }
 
-    fun addSongs(albumId: Int, song: List<SongDto>) {
-        if (!songs.containsKey(albumId)) {
-            songs[albumId] = song
+    fun addSongs(albumId: Int, songs: List<SongDto>) {
+        if (!songsCache.containsKey(albumId)) {
+            songsCache[albumId] = Pair(true, songs)
         }
     }
 
-    fun getSongs(albumId: Int): List<SongDto> {
-        return songs[albumId] ?: listOf()
+    fun getSongs(albumId: Int): Pair<Boolean, List<SongDto>> {
+        return songsCache[albumId] ?: Pair(false, emptyList())
     }
 }


### PR DESCRIPTION
Se agrega micro optimización de cache, para evitar llamados al back cuando no existen canciones

```sh
2024-05-12 18:11:31.994 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 100 - getting songs from network
2024-05-12 18:11:45.893 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 100 - return 2 elements from cache
2024-05-12 18:11:54.078 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 101 - getting songs from network
2024-05-12 18:12:21.911 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 101 - return 0 elements from cache
2024-05-12 18:12:29.196 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 102 - getting songs from network
2024-05-12 18:12:38.613 27775-27775 Cache decision          com.grupo3.vinilos                   D  albumId: 102 - return 0 elements from cache
```